### PR TITLE
follow header conventions

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -42,10 +42,10 @@
 
 ;; 0.9
 ;;    fixed `pkgbuild-tar' (empty directory name: thanks Stefan Husmann)
-;;    new custom variable: pkgbuild-template 
+;;    new custom variable: pkgbuild-template
 ;;    code cleanup
 
-;; 0.8 
+;; 0.8
 ;;    added `pkgbuild-shell-command' and
 ;;      `pkgbuild-shell-command-to-string' (required to always use
 ;;      "/bin/bash" when calling shell functions, which create new
@@ -57,11 +57,11 @@
 
 
 ;; 0.6
-;;    New interactive function pkgbuild-etags (C-c C-e) 
+;;    New interactive function pkgbuild-etags (C-c C-e)
 ;;      create tags table for all PKGBUILDs in your source tree, so you
-;;      can search PKGBUILDs by pkgname. Customize your tags-table-list 
-;;      to include the TAGS file in your source tree. 
-;;    changed default  makepkg-command (disabled ANSI colors in emacs TERM) 
+;;      can search PKGBUILDs by pkgname. Customize your tags-table-list
+;;      to include the TAGS file in your source tree.
+;;    changed default  makepkg-command (disabled ANSI colors in emacs TERM)
 ;;    set default indentation to 2
 
 
@@ -79,7 +79,7 @@
 
 
 ;; 0.3
-;;   Update md5sums line when saving PKGBUILD 
+;;   Update md5sums line when saving PKGBUILD
 ;;     (Can be disabled via custom variable [pkgbuild-update-md5sums-on-save])
 ;;   New interactive function pkgbuild-tar to create Source Tarball (C-c C-a)
 ;;     (Usefull for AUR uploads)
@@ -120,9 +120,9 @@
 (defcustom pkgbuild-template
 "# $Id: pkgbuild-mode.el,v 1.23 2007/10/20 16:02:14 juergen Exp $
 # Maintainer: %s <%s>
-pkgname=%s  
+pkgname=%s
 pkgver=VERSION
-pkgrel=1 
+pkgrel=1
 pkgdesc=\"\"
 arch=('i686' 'x86_64')
 url=\"\"
@@ -262,7 +262,7 @@ Otherwise, it saves all modified buffers without asking."
 
 (defun pkgbuild-trim-right (str)        ;Helper function
   "Trim whitespace from end of the string"
-  (if (string-match "[ \f\t\n\r\v]+$" str -1) 
+  (if (string-match "[ \f\t\n\r\v]+$" str -1)
       (pkgbuild-trim-right (substring str 0 -1))
     str))
 
@@ -280,7 +280,7 @@ Otherwise, it saves all modified buffers without asking."
           l)
       nil)))
 
-(defun pkgbuild-source-locations() 
+(defun pkgbuild-source-locations()
   "find source regions"
   (delete-if (lambda (region) (= (car region) (cdr region))) (loop for item on (pkgbuild-source-points) by 'cddr collect (cons (car item) (cadr item)))))
 
@@ -293,33 +293,33 @@ Otherwise, it saves all modified buffers without asking."
   "same as `shell-command' always uses '/bin/bash'"
   (let ((shell-file-name "/bin/bash"))
     (shell-command COMMAND OUTPUT-BUFFER ERROR-BUFFER)))
-  
+
 (defun pkgbuild-source-check ()
   "highlight sources not available. Return true if all sources are available. This does not work if globbing returns multiple files"
   (interactive)
-  (save-excursion 
+  (save-excursion
     (goto-char (point-min))
     (pkgbuild-delete-all-overlays)
     (if (search-forward-regexp "^\\s-*source=(\\([^()]*\\))" (point-max) t)
         (let ((all-available t)
               (sources (split-string (pkgbuild-shell-command-to-string "source PKGBUILD 2>/dev/null && for source in ${source[@]};do echo $source|sed 's|^.*://.*/||g';done")))
               (source-locations (pkgbuild-source-locations)))
-          (if (= (length sources) (length source-locations)) 
+          (if (= (length sources) (length source-locations))
               (progn
                 (loop for source in sources
                       for source-location in source-locations
                       do (when (not (pkgbuild-find-file source (split-string pkgbuild-source-directory-locations ":")))
-                           (progn 
+                           (progn
                              (setq all-available nil)
                              (pkgbuild-make-overlay (car source-location) (cdr source-location)))))
                 all-available)
             (progn
               (message "cannot verfify sources: don't use globbing %d/%d" (length sources) (length source-locations))
               nil)))
-      (progn 
+      (progn
         (message "no source line found")
         nil))))
-      
+
 (defun pkgbuild-delete-all-overlays ()
   "Delete all the overlays used by pkgbuild-mode."
   (interactive)                         ;test
@@ -355,7 +355,7 @@ Otherwise, it saves all modified buffers without asking."
   (if (not (file-readable-p "PKGBUILD")) (error "Missing PKGBUILD")
     (if (not (pkgbuild-syntax-check)) (error "Syntax Error")
       (if (pkgbuild-source-check)       ;all sources available
-          (save-excursion 
+          (save-excursion
             (goto-char (point-min))
 	    (while (re-search-forward "^[[:alnum:]]+sums=([^()]*)[ \f\t\r\v]*\n?" (point-max) t) ;sum line exists
 	      (delete-region (match-beginning 0) (match-end 0)))
@@ -386,8 +386,8 @@ Otherwise, it saves all modified buffers without asking."
   "Create a default pkgbuild if one does not exist or is empty."
   (interactive)
   (insert (format pkgbuild-template
-		  pkgbuild-user-full-name 
-		  pkgbuild-user-mail-address 
+		  pkgbuild-user-full-name
+		  pkgbuild-user-mail-address
 		  (or (pkgbuild-get-directory (buffer-file-name)) "NAME"))))
 
 (defun pkgbuild-process-check (buffer)
@@ -408,7 +408,7 @@ command."
   "Build this package."
   (interactive
    (if pkgbuild-read-makepkg-command
-       (list (read-from-minibuffer "makepkg command: " 
+       (list (read-from-minibuffer "makepkg command: "
                                    (eval pkgbuild-makepkg-command)
                                    nil nil '(pkgbuild-makepkg-history . 1)))
      (list (eval pkgbuild-makepkg-command))))
@@ -423,7 +423,7 @@ command."
         (save-excursion
           (set-buffer (get-buffer pkgbuild-buffer-name))
           (if (fboundp 'compilation-mode) (compilation-mode pkgbuild-buffer-name))
-          (if buffer-read-only (toggle-read-only)) 
+          (if buffer-read-only (toggle-read-only))
           (goto-char (point-max)))
         (let ((process
                (start-process-shell-command "makepkg" pkgbuild-buffer-name
@@ -460,7 +460,7 @@ command."
         (stdout-buffer (concat "*PKGBUILD(" (pkgbuild-get-directory (buffer-file-name)) ") stdout*")))
     (if (get-buffer stderr-buffer) (kill-buffer stderr-buffer))
     (if (get-buffer stdout-buffer) (kill-buffer stdout-buffer))
-    (if (not (equal 
+    (if (not (equal
               (flet ((message (arg &optional args) nil)) ;Hack disable empty output
                 (pkgbuild-shell-command "source PKGBUILD" stdout-buffer stderr-buffer))
               0))
@@ -483,26 +483,26 @@ command."
             ; (pkgbuild-highlight-line line) TODO
             (setq err-p t)))
       (values err-p line))))
-  
+
 (defun pkgbuild-tarball-files ()
   "Return a list of required files for the tarball package"
   (cons "PKGBUILD"
 	(remove-if (lambda (x) (string-match "^\\(https?\\|ftp\\)://" x))
-		   (split-string (pkgbuild-shell-command-to-string 
+		   (split-string (pkgbuild-shell-command-to-string
 				  "source PKGBUILD 2>/dev/null && echo ${source[@]} $install")))))
-    
+
 (defun pkgbuild-tar-command ()
   "Return default tar command"
   (let* ((tarball-files (pkgbuild-tarball-files))
 	 (dir (car (last (split-string (file-name-directory (buffer-file-name)) "/" t)))))
-    (concat "tar cvzf " dir ".tar.gz -C .. " 
+    (concat "tar cvzf " dir ".tar.gz -C .. "
 	    (mapconcat (lambda (l) (concat dir "/" l)) tarball-files " "))))
 
 (defun pkgbuild-tar (command)
   "Build a tarball containing all required files to build the package."
   (interactive
    (if pkgbuild-read-tar-command
-       (list (read-from-minibuffer "tar command: " 
+       (list (read-from-minibuffer "tar command: "
                                    (pkgbuild-tar-command)
                                    nil nil '(pkgbuild-tar-history . 1)))
      (list (pkgbuild-tar-command))))
@@ -522,14 +522,14 @@ command."
            (start-process-shell-command "tar" pkgbuild-buffer-name
                                         command)))
       (set-process-filter process 'pkgbuild-command-filter))))
-    
+
 
 (defun pkgbuild-browse-url ()
   "Vist URL (if defined in PKGBUILD)"
   (interactive)
   (let ((url (pkgbuild-shell-command-to-string (concat (buffer-string) "\nsource /dev/stdin >/dev/null 2>&1 && echo -n $url" ))))
     (if (string= url "")
-        (message "No URL defined in PKGBUILD") 
+        (message "No URL defined in PKGBUILD")
       (browse-url url))))
 
 ;;;###autoload
@@ -545,20 +545,20 @@ with no args, if that value is non-nil."
   (easy-menu-add pkgbuild-mode-menu)
   ;; This does not work because makepkg requires safed file
   (add-hook 'local-write-file-hooks 'pkgbuild-update-sums-line-hook nil t)
-  (if (= (buffer-size) 0)              
+  (if (= (buffer-size) 0)
       (pkgbuild-initialize)
     (and (pkgbuild-syntax-check) (pkgbuild-source-check))))
 
 (defadvice sh-must-be-shell-mode (around no-check-if-in-pkgbuild-mode activate)
   "Do not check for shell-mode if major mode is \\[pkgbuild-makepkg]"
   (if (not (eq major-mode 'pkgbuild-mode)) ;workaround for older shell-scrip-mode versions
-      ad-do-it))                                
+      ad-do-it))
 
 (defun pkgbuild-etags (toplevel-directory)
   "Create TAGS file by running `etags' recursively on the directory tree `pkgbuild-toplevel-directory'.
   The TAGS file is also immediately visited with `visit-tags-table'."
   (interactive "DToplevel directory: ")
-  (let* ((etags-file (expand-file-name "TAGS" toplevel-directory)) 
+  (let* ((etags-file (expand-file-name "TAGS" toplevel-directory))
 	 (cmd (format pkgbuild-etags-command toplevel-directory etags-file)))
     (require 'etags)
     (message "Running etags to create TAGS file: %s" cmd)


### PR DESCRIPTION
I maintain the [Emacsmirror](https://github.com/emacsmirror) a mirror of Emacs packages here at github.

Eventually I want to provide a package manager which uses this mirror.  This package manager is far from ready but it can already display a list of available packages and details about a package; similar to `package-list-packages` and `describe-package` from the official (as of the to be released Emacs-24) `package.el` package manager.

Since I mirror more than 3000 packages I can not maintain the package metadata manually like the maintainers of `package.el` and `el-get.el` do.  Instead I extract it using the builtin library `lisp-mnt.el` and some custom tools.

Unfortunately many maintainers do not follow these conventions at all or not close enough for these extraction tools to work properly.

I mirror about 800 packages from github among which 120 do not follow the most important convention: how the summary line has to be formatted.

```
;;; foo.el --- Do foo with bar
```

For these 120 packages I am currently creating patches and submitting pull requests like this one.

In some cases I also corrected some other problems concerning the library header and/or deleted trailing whitespace.  If I did not fix anything but the summary line please don't assume that the rest of the header is 100% correct; you might still want to improve it.

Also note that if you maintain additional packages I might not have created such a pull request for them even when they fail to follow the header conventions closely enough.  I do so only (at this point) if the summary line can not be parsed.  So please fix the headers of other libraries yourself.

Please read the official [Header Conventions](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).  Note that while creating this patch I tried to preserve your personal header style while following these conventions as closely as required by the extraction tools.  You might want to further improve the header.

Here are some additional notes.

(To save some time I created this generic pull request message which mentions some common problems which might not all apply to this package.  So please forgive me if some of this is not relevant to you.)
## Summary Line

```
;;; foo.el --- Do foo with bar
```

This has to be on the _first_ line, there are _three semicolons_ and _three dashes_.  The library name has to match the filename (therefor it ends with `.el`) and the provided feature (which obviously doesn't end with `.el` tough). 

If you also define local variables using `-*- ... -*-` then that has to be done on the next line or at the _end_ of the first line.

```
;;; foo.el --- Do foo with bar -*- baz: t -*-
```

or

```
;;; foo.el --- Do foo with bar
;; -*- baz: t -*-
```

There is _not_ reason for `-*- mode: emacs-lisp -*-`. Really Emacs detects that on it's own... Also it is usually not necessary to specify the coding-system.

If the summary is rather long do _not_ split it into two lines, the extraction tools fail to parse that.  Instead make them shorter, which is also useful when the summary is displayed when listing packages or elsewhere.

Don't worry if the summary line is longer than 74 or 80 characters; what matters is the length of the summary sans the leading filename.  It's probably a good idea for the summary to be no longer than ~30-40 characters (or even less) - but again if you can't make it this short without losing essential information don't worry to much.

However this:

```
;;; foo.el --- Foo is a global minor mode to do foo repeatedly while also going to the local bar based on baz
```

can probably be abbreviated as:

```
;;; foo.el --- Do foo with bar
```

Move the longer description to the Commentary section.

Also please make the summary useful to people who don't have the necessary domain knowledge.  E.g. they should be able to tell from the summary that the package implements a major mode for some obscure programming language they have never heard of before and therefor is not of interest to them.
## Commentary Section

```
;;; Commentary:
```

This begins with _three_ dashes and ends with a colon.

The first sentence or paragraph should repeat the information from the summary line.  Try to be brief but use whole sentences - this isn't the summary line, we have enough room.

If you feel the need to provide installation instructions preferably do so toward the end of the commentary section.

You might even want to create a separate section for the installation instructions.  This breaks with the header conventions (or at least isn't mentioned there) but has the advantage that tools that extract the commentary _won't_ include the installation instructions.  And that is useful because these tools are commonly used to extract information for the benefit of a package manager, so the generic instructions would actually be incorrect because installation happens with something like `M-x pm-install-package`.

```
;;; Commentary:

;; This package...

;;; Installation:

;; Put `foo.el' in the `load-path' and add
;;
;;   (foo-mode)
;;
;; to your init file.
```

In any case do _not only_ provide the installation instructions.  At the very least duplicate the summary line at the beginning of the commentary section.

Also if your installation instructions are as generic as in the example above consider dropping them completely.  This is common knowledge and for a complete beginner who never installed a package before yours (how likely is that?) this isn't enough information anyway (what is that `load-path`, where is my init file?).  Don't duplicate the generic installation instructions from the Emacs info page in an incomplete way - just inform about _additional_ things to consider.
## Code Section

Put `;;; Code:` after the commentary section and before the first `require` form.  This might be kind of pointless but not following this convention just because is also rather pointless.  (By the way `lm-commentary` will fail without this but my variant of that function does not.)

```
;;; Commentary:

;; This package...

;;; Code:

(require 'bar)
...
```
## Maintainer and Author Header Lines

The convention requests both to be specified.  In my opinion you can omit `Maintainer` if it is equal to `Author`.

```
;; Author: Jonas Bernoulli <jonas@bernoul.li>
;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
```

Multiple authors can be specified but only one maintainer.  Note that you can't use `Authors` (plural) when there are multiple authors - `lm-authors` won't detect it (though my variant does).

```
;; Author: Jonas Bernoulli <jonas@bernoul.li>
;;      Linus Bernoulli <linus@bernoulli.cc>
  [^tab] (only one tab, nothing else)
```

Please consider _not_ obfuscation the email address and wrap it with `<...>` even if you do obfuscate it.
## Footer Line

```
(provide 'foo)
;;; foo.el ends here
```

Don't forget to provide the appropriate feature.  The `;;; foo.el ends here`?  Omit it if you want I don't care.  I think this is rather pointless in the age of distributed version control, then again not everybody has arrived there yet.  I don't omit it in my libraries - that would weaken my position when telling people that following the conventions is important :-)
