### PR TITLE
Sources renaming is not supported

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -303,16 +303,13 @@ Otherwise, it saves all modified buffers without asking."
     (pkgbuild-delete-all-overlays)
     (if (search-forward-regexp "^\\s-*source=(\\([^()]*\\))" (point-max) t)
         (let ((all-available t)
-              (sources (split-string (pkgbuild-shell-command-to-string "source PKGBUILD 2>/dev/null && for source in ${source[@]};do echo $source|sed 's|^.*://.*/||g';done")))
-              (sources-renamed (split-string (pkgbuild-shell-command-to-string "source PKGBUILD 2>/dev/null && for source in ${source[@]};do echo $source|sed 's|::.*://.*||g';done")))
+              (sources (split-string (pkgbuild-shell-command-to-string "source PKGBUILD 2>/dev/null && for source in ${source[@]};do echo $source|sed 's|:.*://.*||g'|sed 's|^.*://.*/||g';done")))
               (source-locations (pkgbuild-source-locations)))
           (if (= (length sources) (length source-locations))
               (progn
                 (loop for source in sources 
-                      for source-renamed in sources-renamed
                       for source-location in source-locations
-                      do (when (and (not (pkgbuild-find-file source (split-string pkgbuild-source-directory-locations ":")))
-                                    (not (pkgbuild-find-file source-renamed (split-string pkgbuild-source-directory-locations ":"))))
+                      do (when (not (pkgbuild-find-file source (split-string pkgbuild-source-directory-locations ":")))
                            (progn
                              (setq all-available nil)
                              (pkgbuild-make-overlay (car source-location) (cdr source-location)))))


### PR DESCRIPTION
Hi,

particularly when pulling something from github tags (like i do in one of the packages i manage on the AUR) it's useful to rename sources (see [here](https://wiki.archlinux.org/index.php/PKGBUILD#source)).
Currently this mode does not support source renaming: the pkgbuild-source-check function fails in finding those files. It's possible to add the functionality to this mode?
