### PR TITLE
Adds "$srcdir" to all of the chdir statements

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -156,26 +156,26 @@ noextract=()
 md5sums=()
 
 prepare() {
-  cd $pkgname-$pkgver
+  cd "$srcdir/$pkgname-$pkgver"
 
   patch -p1 -i \"$srcdir/$pkgname-$pkgver.patch\"
 }
 
 build() {
-  cd $pkgname-$pkgver
+  cd "$srcdir/$pkgname-$pkgver"
 
   ./configure --prefix=/usr
   make
 }
 
 check() {
-  cd $pkgname-$pkgver
+  cd "$srcdir/$pkgname-$pkgver"
 
   make -k check
 }
 
 package() {
-  cd $pkgname-$pkgver
+  cd "$srcdir/$pkgname-$pkgver"
 
   make DESTDIR=\"$pkgdir/\" install
 }

--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -156,26 +156,26 @@ noextract=()
 md5sums=()
 
 prepare() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd \"$srcdir/$pkgname-$pkgver\"
 
   patch -p1 -i \"$srcdir/$pkgname-$pkgver.patch\"
 }
 
 build() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd \"$srcdir/$pkgname-$pkgver\"
 
   ./configure --prefix=/usr
   make
 }
 
 check() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd \"$srcdir/$pkgname-$pkgver\"
 
   make -k check
 }
 
 package() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd \"$srcdir/$pkgname-$pkgver\"
 
   make DESTDIR=\"$pkgdir/\" install
 }


### PR DESCRIPTION
I don't understand why "$srcdir" isn't already present, since, AFAICT, without it the PKGBUILD is completely broken since a "$pkgname-$pkgver" directory doesn't exist except within "$srcdir", which we cannot guarantee that we are already within.