### PR TITLE
fix handling of sums_${arch} lines

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -370,12 +370,15 @@ Otherwise, it saves all modified buffers without asking."
       (if (pkgbuild-source-check)       ;all sources available
           (save-excursion
             (goto-char (point-min))
-	    (while (re-search-forward "^[[:alnum:]]+sums=([^()]*)[ \f\t\r\v]*\n?" (point-max) t) ;sum line exists
-	      (delete-region (match-beginning 0) (match-end 0)))
-	    (goto-char (point-min))
-	    (if (re-search-forward "^source=([^()]*)" (point-max) t)
-                (insert "\n")
-              (error "Missing source line"))
+            (while (re-search-forward "^[[:space:]]*\\\(md\\\|sha\\\)[[:digit:]]+sums\\\(_[^=]+\\\)?=([^()]*)[ \f\t\r\v]*\n?" (point-max) t) ;sum line exists
+              (delete-region (match-beginning 0) (match-end 0)))
+            (goto-char (point-max))
+            (if (re-search-backward "^[[:space:]]*source\\\(_[^=]+\\\)?=([^()]*)" (point-min) t)
+                (progn
+                  (goto-char (match-end 0))
+                  (insert "\n"))
+              (error "Missing source line")
+              (goto-char (point-max)))
             (insert (pkgbuild-trim-right (pkgbuild-sums-line))))))))
 
 (defun pkgbuild-about-pkgbuild-mode (&optional arg)


### PR DESCRIPTION
* delete all sums-lines even those with _${arch}
* insert the new sums-lines after the last source-array
* unfortunately 'makepkg -g' only creates 'md5sums_${arch}' -- for sums
  without arch it can handle all available integrity sums