### PR TITLE
fix error at the time of syntax check

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -485,7 +485,7 @@ command."
     (if (get-buffer stderr-buffer) (kill-buffer stderr-buffer))
     (if (get-buffer stdout-buffer) (kill-buffer stdout-buffer))
     (if (not (equal
-              (flet ((message (arg &optional args) nil)) ;Hack disable empty output
+              (flet ((message (arg &rest args) nil)) ;Hack disable empty output
                 (shell-command "bash -c 'source PKGBUILD'" stdout-buffer stderr-buffer))
               0))
         (multiple-value-bind (err-p line) (pkgbuild-postprocess-stderr stderr-buffer)


### PR DESCRIPTION
On Emacs 24.5.1, the following error has occurred because message function argument is invalid.

```
Debugger entered--Lisp error: (wrong-number-of-arguments (lambda (arg &optional args) (progn nil)) 3)
  message("(Shell command failed with code %d and %s)" 1 "some error output")
```
