### PR TITLE
pkgbuild: Replace flet in favor of cl-labels

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -490,7 +490,7 @@ command."
     (if (get-buffer stderr-buffer) (kill-buffer stderr-buffer))
     (if (get-buffer stdout-buffer) (kill-buffer stdout-buffer))
     (if (not (equal
-              (flet ((message (arg &optional args) nil)) ;Hack disable empty output
+              (cl-labels ((message (arg &optional args) nil)) ;Hack disable empty output
                 (shell-command "bash -c 'source PKGBUILD'" stdout-buffer stderr-buffer))
               0))
         (multiple-value-bind (err-p line) (pkgbuild-postprocess-stderr stderr-buffer)


### PR DESCRIPTION
Does the same thing in this context and stops the `flet` depreciation warning.