### PR TITLE
Remove call to obsolete `easy-menu-add`

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -548,7 +548,6 @@ with no args, if that value is non-nil."
   (set (make-local-variable 'sh-basic-offset) 2) ;This is what judd uses
   (set (make-local-variable 'compile-command) pkgbuild-makepkg-command)
   (sh-set-shell "/bin/bash")
-  (easy-menu-add pkgbuild-mode-menu)
   ;; This does not work because makepkg req. saved file
   (add-hook 'write-file-functions 'pkgbuild-update-sums-line-hook nil t)
   (unless (memq 'pkgbuild-flymkake-check flymake-diagnostic-functions)


### PR DESCRIPTION
For a long time, `easy-menu-add` has been a no-op function in Emacs as
it is aliased to `ignore`. In Emacs 28, this function has been made
obsolete.

This commit removes the `easy-menu-add` call this package has.