### PR TITLE
only init if init var is true

### DIFF
--- a/pkgbuild-mode.el
+++ b/pkgbuild-mode.el
@@ -487,7 +487,8 @@ with no args, if that value is non-nil."
   (unless (memq 'pkgbuild-flymkake-check flymake-diagnostic-functions)
     (make-local-variable 'flymake-diagnostic-functions)
     (push 'pkgbuild-flymkake-check flymake-diagnostic-functions))
-  (if (= (buffer-size) 0)
+  (if (and (= (buffer-size) 0)
+	   pkgbuild-initialize)
       (pkgbuild-initialize)
     (flymake-mode 1)))
 


### PR DESCRIPTION
The doc for `pkgbuild-initialize` say that we only init blank files if it's true, but we don't actually check this var. Now if I set the var to nil, it won't init new files (which is what I want)